### PR TITLE
All themes / sites to customize menu display.

### DIFF
--- a/localgov_subsites.module
+++ b/localgov_subsites.module
@@ -17,6 +17,8 @@ function localgov_subsites_theme($existing, $type, $theme, $path) {
       'variables' => [
         'menu_name' => '',
         'items' => [],
+        'current_entity' => NULL,
+        'overview_entity' => NULL,
       ],
     ],
     'subsite_banner' => [

--- a/src/Plugin/Block/SubsitesNavigationBlock.php
+++ b/src/Plugin/Block/SubsitesNavigationBlock.php
@@ -57,6 +57,7 @@ class SubsitesNavigationBlock extends SubsitesAbstractBlockBase {
       $entities = $mapper->loadAndAccessCheckEntitysForTreeNodes('node', $tree, $cache);
       $items = $this->nestTree($tree, $ancestors, $entities);
       $subsite_id = $entities[$ancestors[0]]->id();
+      $overview_entity = $entities[$ancestors[0]];
     }
     elseif ($subsite_entity->bundle('localgov_subsites_overview')) {
       // Subsite overview page with no children.
@@ -64,6 +65,7 @@ class SubsitesNavigationBlock extends SubsitesAbstractBlockBase {
       // Cache metadata already has this entity.
       $items = [$this->formatItem($subsite_entity, TRUE)];
       $subsite_id = $subsite_entity->id();
+      $overview_entity = $subsite_entity;
     }
 
     if ($items) {
@@ -71,6 +73,8 @@ class SubsitesNavigationBlock extends SubsitesAbstractBlockBase {
         '#theme' => 'subsite_navigation',
         '#menu_name' => 'subsite_navigation:' . $subsite_id,
         '#items' => $items,
+        '#current_entity' => $subsite_entity,
+        '#overview_entity' => $overview_entity,
       ];
     }
 


### PR DESCRIPTION
Just exposes the entities to the theme.

Use case lambeth adds a field on overview to set when and if the menu is displayed in the header horizontally, an addition and alternative to the rhs.

By passing the overview and the page itself this just allows full flexibility without trying to second guess what variations there are.

Localgov could add in some default options if some become more common. At the moment it's not really needed with the default configuration.