### PR TITLE
PHP constraint for test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+ 
       - name: Clone drupal_container
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Tests should run under PHP 7.4 and not the default PHP 8.x