### PR TITLE
Update Quote template to follow Drupal standards

### DIFF
--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-quote.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-quote.html.twig
@@ -42,6 +42,10 @@
 {%
   set classes = [
     "pull-out-quote",
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
   ]
 %}
 
@@ -51,7 +55,7 @@
   </div>
   
   {% if paragraph.localgov_author.value %}
-    <footer>
+    <footer class="pull-out-quote__author">
       - {{ paragraph.localgov_author.value }}
     </footer>
   {% endif %}

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-quote.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-quote.html.twig
@@ -46,7 +46,10 @@
 %}
 
 <blockquote{{ attributes.addClass(classes) }}>
-  <p>{{ content.localgov_text_plain }}</p>
+  <div class="pull-out-quote__content">
+    {{ content.localgov_text_plain }}
+  </div>
+  
   {% if paragraph.localgov_author.value %}
     <footer>
       - {{ paragraph.localgov_author.value }}

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-quote.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-quote.html.twig
@@ -38,7 +38,27 @@
  * @ingroup themeable
  */
 #}
-<blockquote class="pull-out-quote">
+
+{%
+  set classes = [
+    "pull-out-quote",
+  ]
+%}
+
+<blockquote{{ attributes.addClass(classes) }}>
   <p>{{ content.localgov_text_plain }}</p>
-  <footer>- {{ content.localgov_author }}</footer>
+  {% if paragraph.localgov_author.value %}
+    <footer>
+      - {{ paragraph.localgov_author.value }}
+    </footer>
+  {% endif %}
 </blockquote>
+
+{% block content_variable %}
+  {#
+    This allows the cache_context to bubble up for us, without having to
+    individually list every field in
+    {{ content|without('field_name', 'field_other_field', 'field_etc') }}
+  #}
+  {% set catch_cache = content|render %}
+{% endblock %}


### PR DESCRIPTION
1. Creates classes variable
2. Uses `attributes` so we have attributes for accessibility, quick edit, etc
3. Removes `p` around the quote, as this was resulting in an empty `p` tag, since the field itself renders a `div` inside it
4. Checks if the author field is filled in before rendering it, or else we get an empty `footer`
5. Adds a catch_cache variable so cache metadata can bubble up properly