### PR TITLE
update Fact Box template to follow drupal standards

### DIFF
--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-fact-box.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-fact-box.html.twig
@@ -39,11 +39,19 @@
  */
 #}
 
+{% if paragraph.localgov_background.value %}
+  {% set factbox_bg = paragraph.localgov_background.value %}
+{% endif %}
+
 {%
   set classes = [
     'fact-box',
-    paragraph.field_background.getValue[0].value ? 
-      'fact-box--' ~ paragraph.field_background.getValue[0].value : '',
+    factbox_bg ? 'fact-box--has-bg',
+    factbox_bg ? 'fact-box--' ~ factbox_bg,
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
   ]
 %}
 

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-fact-box.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-fact-box.html.twig
@@ -38,11 +38,42 @@
  * @ingroup themeable
  */
 #}
+
 {%
-  set class = 'fact-box-' ~ paragraph.field_background.getValue[0].value
+  set classes = [
+    'fact-box',
+    paragraph.field_background.getValue[0].value ? 
+      'fact-box--' ~ paragraph.field_background.getValue[0].value : '',
+  ]
 %}
-<div class="fact-box {{ class }} level-height-item">
-  <p class="fact-opening">{{ content.localgov_above_text }}</p>
-  <p class="fact">{{ content.localgov_fact }}</p>
-  <p class="fact-closing">{{ content.localgov_below_text }}</p>
+
+<div{{attributes.addClass(classes)}}>
+
+	{% if paragraph.localgov_above_text.value %}
+		<p class="fact-opening">
+      {{ paragraph.localgov_above_text.value }}
+    </p>
+	{% endif %}
+
+	{% if paragraph.localgov_fact.value %}
+		<p class="fact">
+      {{ paragraph.localgov_fact.value }}
+    </p>
+	{% endif %}
+
+	{% if paragraph.localgov_below_text.value %}
+		<p class="fact-closing">
+      {{ paragraph.localgov_below_text.value }}
+    </p>
+	{% endif %}
+
 </div>
+
+{% block content_variable %}
+  {#
+    This allows the cache_context to bubble up for us, without having to
+    individually list every field in
+    {{ content|without('field_name', 'field_other_field', 'field_etc') }}
+  #}
+  {% set catch_cache = content|render %}
+{% endblock %}

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-fact-box.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-fact-box.html.twig
@@ -50,19 +50,19 @@
 <div{{attributes.addClass(classes)}}>
 
 	{% if paragraph.localgov_above_text.value %}
-		<p class="fact-opening">
+		<p class="fact-box__opening">
       {{ paragraph.localgov_above_text.value }}
     </p>
 	{% endif %}
 
 	{% if paragraph.localgov_fact.value %}
-		<p class="fact">
+		<p class="fact-box__fact">
       {{ paragraph.localgov_fact.value }}
     </p>
 	{% endif %}
 
 	{% if paragraph.localgov_below_text.value %}
-		<p class="fact-closing">
+		<p class="fact-box__closing">
       {{ paragraph.localgov_below_text.value }}
     </p>
 	{% endif %}


### PR DESCRIPTION
This PR:

1. Adds attributes to the container wrapper, so we have quicklinks etc working (which in turn fixes a JS error being reported in the console).
2. Only prints the background class if there is a value in the background field
3. Only prints individual fields if there is a value in them
4. Prints only the field values, or else we get empty `p` tags, since the field itself prints a div
4. Removes the hard-coded bootstrap classes - we can't presume all themes will use bootstrap
5. Removes extra level-height-item class - this should be a BEM style class in here, or else added conditionally in the `classes` array
6. Uses BEM naming convention for the classes for above/fact/below
7. Adds a content variable for better cache bubbling
