### PR TITLE
update Banner Primary template to follow drupal standards

### DIFF
--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-banner-primary.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-banner-primary.html.twig
@@ -49,7 +49,7 @@
   ] 
 %}
 
-<div{{attributes.addClass(classes)}}>
+<div{{ attributes.addClass(classes) }}>
 	<div class="subsite-banner__inner">
     <div class="subsite-banner__content">
       {{ content }}

--- a/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-banner-primary.html.twig
+++ b/modules/localgov_subsites_paragraphs/templates/paragraph--localgov-banner-primary.html.twig
@@ -1,10 +1,58 @@
-<div class="bg-white">
-  <div class="banner-header mx-auto">
-    <div class="relative subsite-banner{{ call_to_action ? ' subsite-banner--overview' }}">
-      <div class="subsite-banner__image">
-      {{ content }}
-      </div>
-    </div>
-  </div>
-</div>
+{#
+/**
+ * @file
+ * Default theme implementation to display a Box links listing paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{% 
+  set classes = [
+    'subsite-banner',
+    call_to_action ? 'subsite-banner--with-cta',
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+  ] 
+%}
 
+<div{{attributes.addClass(classes)}}>
+	<div class="subsite-banner__inner">
+    <div class="subsite-banner__content">
+      {{ content }}
+    </div>
+	</div>
+</div>


### PR DESCRIPTION
This PR:
1. Adds attributes to the container wrapper, so we have quicklinks etc working (which in turn fixes a JS error being reported in the console).
2. Removes the hardcoded `bg-white` class/div - this should be added via an option in the paragraph type: if all banners need this, then it should be added via CSS
3. Removes the hard-coded bootstrap classes - we can't presume all themes will use bootstrap
4. Uses BEM naming convention for the classes
