### PR TITLE
Tagged feature/composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "drupal/layout_paragraphs": "dev-1.0.x",
     "drupal/tablefield": "dev-2.x",
     "drupal/viewsreference": "^2.0",
-    "localgovdrupal/localgov_paragraphs": "^1.0@alpha"
+    "localgovdrupal/localgov_paragraphs": "^1.0"
   },
   "extra": {
     "composer-exit-on-patch-failure": true,

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
   "minimum-stability": "dev",
   "require": {
     "drupal/entity_hierarchy": "^2.24",
-    "drupal/layout_paragraphs": "dev-1.0.x",
-    "drupal/tablefield": "dev-2.x",
+    "drupal/layout_paragraphs": "^1.0.0-beta5",
+    "drupal/tablefield": "^2.2",
     "drupal/viewsreference": "^2.0",
     "localgovdrupal/localgov_paragraphs": "^1.0"
   },


### PR DESCRIPTION
Use non-beta localgov dependencies.
Two dev- dependencies with no checkout hash attached, hopefully both now in tagged versions.