### PR TITLE
Remove BS row class from layout region container

### DIFF
--- a/templates/layout--onecol--flexible.html.twig
+++ b/templates/layout--onecol--flexible.html.twig
@@ -17,7 +17,7 @@
 %}
 {% if content %}
   <div{{ attributes.addClass(classes) }}>
-    <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content', 'row') }}>
+    <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content') }}>
       {{ content.content }}
     </div>
   </div>


### PR DESCRIPTION
I'm working on an issue with text not lining up in Croydon and have narrowed it down to a 'row' class in the following file that's adding negative margins:

https://github.com/localgovdrupal/localgov_subsites/blob/master/templates/layout--onecol--flexible.html.twig

rather than fix it within the croydon theme I think it would be best to remove it at the local gov theme level - this class relies on being within a container class called 'container' which isn't declared here so removing it shouldn't be an issue. Looking at the git log this seems to be a BHC inherited thing - it was probably given the container class when in use at Brighton.