### PR TITLE
Table field to stable.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require": {
     "drupal/entity_hierarchy": "^2.24",
     "drupal/layout_paragraphs": "^1.0.0",
-    "drupal/tablefield": "dev-2.x",
+    "drupal/tablefield": "^2.2",
     "drupal/viewsreference": "^2.0",
     "localgovdrupal/localgov_core": "^2.1",
     "localgovdrupal/localgov_paragraphs": "^2.0"


### PR DESCRIPTION
Unless requires something since release 28 October 2020 at which point
it would be best to tag it to a commit rather than running with -dev.

2.x follow-up to the 1.x PR #37 