### PR TITLE
Changes ahead of release 2.0.7

### DIFF
--- a/localgov_subsites.info.yml
+++ b/localgov_subsites.info.yml
@@ -15,7 +15,7 @@ dependencies:
   - entity_hierarchy:entity_hierarchy
   - entity_hierarchy:entity_hierarchy_breadcrumb
   - field_group:field_group
-  - paragraphs:paragraphs
+  - paragraphs:paragraphs (>=8.x-1.13)
   - layout_paragraphs:layout_paragraphs
   - localgov_subsites:localgov_subsites_paragraphs
   - localgov_core:localgov_core

--- a/modules/localgov_subsites_paragraphs/tests/src/Functional/SubsitesParagraphsAdministrationTest.php
+++ b/modules/localgov_subsites_paragraphs/tests/src/Functional/SubsitesParagraphsAdministrationTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\localgov_subsites_paragraphs\Functional;
 
-use Drupal\Tests\paragraphs\Functional\Classic\ParagraphsTestBase;
+use Drupal\Tests\paragraphs\Functional\WidgetLegacy\ParagraphsTestBase;
 
 /**
  * Tests the configuration of localgov_paragraphs.


### PR DESCRIPTION
Changes:
- [Adjust test base class](https://github.com/localgovdrupal/localgov_subsites/pull/75).  Caused by paragraphs version [8.x-1.13](https://www.drupal.org/project/paragraphs/releases/8.x-1.13).