### PR TITLE
Add search result highlight to search result highlight display

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_subsites_overview.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_subsites_overview.search_result.yml
@@ -16,18 +16,17 @@ targetEntityType: node
 bundle: localgov_subsites_overview
 mode: search_result
 content:
-  localgov_subsites_summary:
-    type: basic_string
-    weight: 0
-    region: content
-    label: hidden
+  search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
+  content_moderation_control: true
   links: true
   localgov_subsites_banner: true
   localgov_subsites_content: true
   localgov_subsites_hide_menu: true
   localgov_subsites_pages: true
+  localgov_subsites_summary: true
   localgov_subsites_theme: true
-  search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.localgov_subsites_page.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_subsites_page.search_result.yml
@@ -16,17 +16,16 @@ targetEntityType: node
 bundle: localgov_subsites_page
 mode: search_result
 content:
-  localgov_subsites_summary:
-    type: basic_string
-    weight: 0
-    region: content
-    label: hidden
+  search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
+  content_moderation_control: true
   links: true
   localgov_subsites_banner: true
   localgov_subsites_content: true
   localgov_subsites_parent: true
+  localgov_subsites_summary: true
   localgov_subsites_topic: true
-  search_api_excerpt: true

--- a/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/tests/src/Functional/LocalgovIntegrationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\Tests\localgov_subsites\Functional;
+
+use Drupal\Tests\Traits\Core\CronRunTrait;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+
+/**
+ * Tests pages working together with LocalGov: pathauto, services, search.
+ *
+ * @group localgov_directories
+ */
+class LocalgovIntegrationTest extends BrowserTestBase {
+
+  use NodeCreationTrait;
+  use AssertBreadcrumbTrait;
+  use CronRunTrait;
+
+  /**
+   * Test breadcrumbs in the Standard profile.
+   *
+   * @var string
+   */
+  protected $profile = 'standard';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stable';
+
+  /**
+   * A user with permission to bypass content access checks.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * The node storage.
+   *
+   * @var \Drupal\node\NodeStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'localgov_core',
+    'localgov_services_landing',
+    'localgov_services_sublanding',
+    'localgov_services_navigation',
+    'localgov_subsites',
+    'localgov_search',
+    'localgov_search_db',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->drupalPlaceBlock('system_breadcrumb_block');
+    $this->adminUser = $this->drupalCreateUser([
+      'bypass node access',
+      'administer nodes',
+    ]);
+    $this->nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
+  }
+
+  /**
+   * LocalGov Search integration.
+   */
+  public function testLocalgovSearch() {
+
+    // Confirm the localgov_subsites_overview nodes work with database search.
+    $title = 'Subsite overview 1';
+    $overview_summary = 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.';
+    $this->createNode([
+      'title' => $title,
+      'type' => 'localgov_subsites_overview',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_subsites_summary' => $overview_summary,
+    ]);
+    $this->cronRun();
+    $this->drupalGet('search', ['query' => ['s' => 'bias+dogma+revelation']]);
+    $this->assertSession()->pageTextContains($title);
+    $this->assertSession()->responseContains('<strong>bias</strong>');
+    $this->assertSession()->responseContains('<strong>dogma</strong>');
+    $this->assertSession()->responseContains('<strong>revelation</strong>');
+
+    // Confirm the localgov_subsites_page nodes work with database search.
+    $page_summary = "Time isn't the main thing. It's the only thing.";
+    $this->createNode([
+      'title' => 'Subsite subsite page',
+      'type' => 'localgov_subsites_page',
+      'status' => NodeInterface::PUBLISHED,
+      'localgov_subsites_summary' => $page_summary,
+    ]);
+    $this->cronRun();
+    $this->drupalGet('search', ['query' => ['s' => 'time+main+only']]);
+    $this->assertSession()->pageTextContains('Subsite subsite page');
+    $this->assertSession()->responseContains('<strong>time</strong>');
+    $this->assertSession()->responseContains('<strong>main</strong>');
+    $this->assertSession()->responseContains('<strong>only</strong>');
+  }
+
+}


### PR DESCRIPTION
Fix #97

Usual cavet about using search_api as dependency applies.
(If not using search_api, the search result display will be blank)
