### PR TITLE
Remove dependency on Layout Paragraphs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,7 @@
     "patchLevel": {
       "drupal/core": "-p2"
     },
-    "patches": {
-      "drupal/layout_paragraphs": {
-        "Fix missing schema for link in view mode: https://www.drupal.org/project/layout_paragraphs/issues/3161998": "https://www.drupal.org/files/issues/2020-07-28/missing_link_config_schema-3161998-2.patch"
-      }
+    "patches": {}
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
   "minimum-stability": "dev",
   "require": {
     "drupal/entity_hierarchy": "^2.24",
-    "drupal/layout_paragraphs": "^1.0.0",
     "drupal/tablefield": "^2.2",
     "drupal/viewsreference": "^2.0",
     "localgovdrupal/localgov_core": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,5 @@
       "drupal/core": "-p2"
     },
     "patches": {}
-    }
   }
 }

--- a/config/install/core.entity_view_display.node.localgov_subsites_overview.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_subsites_overview.default.yml
@@ -22,7 +22,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      link: false
+      link: '
     third_party_settings: {  }
     region: content
 hidden:

--- a/config/install/core.entity_view_display.node.localgov_subsites_overview.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_subsites_overview.default.yml
@@ -22,7 +22,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      link: '
+      link: ''
     third_party_settings: {  }
     region: content
 hidden:

--- a/config/install/core.entity_view_display.node.localgov_subsites_overview.search_index.yml
+++ b/config/install/core.entity_view_display.node.localgov_subsites_overview.search_index.yml
@@ -23,7 +23,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      link: false
+      link: ''
     third_party_settings: {  }
     region: content
   localgov_subsites_summary:

--- a/config/install/core.entity_view_display.node.localgov_subsites_page.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_subsites_page.default.yml
@@ -21,7 +21,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      link: false
+      link: ''
     third_party_settings: {  }
     type: layout_paragraphs
     region: content

--- a/config/install/core.entity_view_display.node.localgov_subsites_page.search_index.yml
+++ b/config/install/core.entity_view_display.node.localgov_subsites_page.search_index.yml
@@ -23,7 +23,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      link: false
+      link: ''
     third_party_settings: {  }
     type: layout_paragraphs
     region: content


### PR DESCRIPTION
Dependency on Layout Paragraphs with be added to LocalGov Paragraphs. This will allow use to upgrade to Layout Paragraphs 2.x without further releases.

See:
  - #85 
  - https://github.com/localgovdrupal/localgov_page/pull/38
  - https://github.com/localgovdrupal/localgov_paragraphs/pull/83
  - https://github.com/localgovdrupal/localgov_microsites/issues/84