### PR TITLE
Update Entity Hierarchy to ^3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "drupal/entity_hierarchy": "^2.24",
+    "drupal/entity_hierarchy": "^3.3",
     "drupal/tablefield": "^2.2",
     "drupal/viewsreference": "^2.0",
     "localgovdrupal/localgov_core": "^2.1",


### PR DESCRIPTION
Fix #104

Update Entity Hierarchy to 3.3 branch, as 2.x branch is now marked as obsolete
Note: A full cache rebuild is required after updating.