### PR TITLE
Fix PHP error on subsite page when overview is unpublished

### DIFF
--- a/src/Plugin/Block/SubsitesNavigationBlock.php
+++ b/src/Plugin/Block/SubsitesNavigationBlock.php
@@ -7,6 +7,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Template\Attribute;
+use Drupal\Node\NodeInterface;
 
 /**
  * Class SubsiteNavigationBlock.
@@ -56,8 +57,17 @@ class SubsitesNavigationBlock extends SubsitesAbstractBlockBase {
       $mapper = \Drupal::service('entity_hierarchy.entity_tree_node_mapper');
       $entities = $mapper->loadAndAccessCheckEntitysForTreeNodes('node', $tree, $cache);
       $items = $this->nestTree($tree, $ancestors, $entities);
-      $subsite_id = $entities[$ancestors[0]]->id();
-      $overview_entity = $entities[$ancestors[0]];
+
+      // Sometimes the subsite is missing if the overview is unpublished and
+      // the user is anonymous, in which case set it to NULL.
+      if (!empty($entities[$ancestors[0]]) && $entities[$ancestors[0]] instanceof NodeInterface) {
+        $subsite_id = $entities[$ancestors[0]]->id();
+        $overview_entity = $entities[$ancestors[0]];
+      }
+      else {
+        $subsite_id = NULL;
+        $overview_entity = NULL;
+      }
     }
     elseif ($subsite_entity->bundle('localgov_subsites_overview')) {
       // Subsite overview page with no children.

--- a/src/Plugin/Block/SubsitesNavigationBlock.php
+++ b/src/Plugin/Block/SubsitesNavigationBlock.php
@@ -63,10 +63,18 @@ class SubsitesNavigationBlock extends SubsitesAbstractBlockBase {
       if (!empty($entities[$ancestors[0]]) && $entities[$ancestors[0]] instanceof NodeInterface) {
         $subsite_id = $entities[$ancestors[0]]->id();
         $overview_entity = $entities[$ancestors[0]];
+        $cache->addCacheableDependency($overview_entity);
       }
       else {
         $subsite_id = NULL;
         $overview_entity = NULL;
+
+        // But we still need the parent subsite for cache purposes.
+        $entities = $mapper->loadEntitiesForTreeNodesWithoutAccessChecks('node', $tree, $cache);
+        if (!empty($entities[$ancestors[0]]) && $entities[$ancestors[0]] instanceof NodeInterface) {
+          $overview_entity_for_cache = $entities[$ancestors[0]];
+          $cache->addCacheableDependency($overview_entity_for_cache);
+        }
       }
     }
     elseif ($subsite_entity->bundle('localgov_subsites_overview')) {

--- a/templates/subsite-navigation.html.twig
+++ b/templates/subsite-navigation.html.twig
@@ -49,7 +49,9 @@
         {% if item.in_active_trail %}
           {{ item.title }}
         {% else %}
-          {{ link(item.title, item.url) }}
+          {% if item.url is not empty %}
+            {{ link(item.title, item.url) }}
+          {% endif %}
         {% endif %}
         {% if item.below %}
           {{ subsite_navigation.menu_links(item.below, attributes, menu_level + 1) }}

--- a/tests/src/Functional/SubsiteBlocksTest.php
+++ b/tests/src/Functional/SubsiteBlocksTest.php
@@ -238,6 +238,7 @@ class SubsiteBlocksTest extends BrowserTestBase {
     $subsite_overview->set('localgov_subsites_hide_menu', ['value' => 0]);
     $subsite_overview->set('status', NodeInterface::NOT_PUBLISHED);
     $subsite_overview->save();
+    drupal_flush_all_caches();
     $this->drupalGet($subsite_page1->toUrl()->toString());
     $this->assertSession()->responseContains('block-localgov-subsite-navigation');
     $this->assertSession()->responseContains($subsite_page1_title);

--- a/tests/src/Functional/SubsiteBlocksTest.php
+++ b/tests/src/Functional/SubsiteBlocksTest.php
@@ -233,6 +233,16 @@ class SubsiteBlocksTest extends BrowserTestBase {
     $this->assertSession()->responseNotContains('block-localgov-subsite-navigation');
     $this->drupalGet($subsite_page1->toUrl()->toString());
     $this->assertSession()->responseNotContains('block-localgov-subsite-navigation');
+
+    // Test the navigation is still avalible with an unpublished overview node.
+    $subsite_overview->set('localgov_subsites_hide_menu', ['value' => 0]);
+    $subsite_overview->set('status', NodeInterface::NOT_PUBLISHED);
+    $subsite_overview->save();
+    $this->drupalGet($subsite_page1->toUrl()->toString());
+    $this->assertSession()->responseContains('block-localgov-subsite-navigation');
+    $this->assertSession()->responseContains($subsite_page1_title);
+    $this->assertSession()->responseContains($subsite_page2_title);
+    $this->assertSession()->pageTextNotContains($subsite_overview_title);
   }
 
 }


### PR DESCRIPTION
Fix #118

Set the $subsite_id and $overview_entity to NULL if the overview is unpublished and the user doesn't have access to it. (It's not found in loadAndAccessCheckEntitysForTreeNodes).

This also required a change in the subsite navigation twig to check that the link has a url before attempting to output it, a simmilar change will be needed on any theme that has implemented the template.

Note: The test fails here due to the way the blocks cache.
