### PR TITLE
Fix: Suppressing PHP 8.2 warnings

### DIFF
--- a/src/Plugin/Block/SubsitesAbstractBlockBase.php
+++ b/src/Plugin/Block/SubsitesAbstractBlockBase.php
@@ -20,6 +20,13 @@ abstract class SubsitesAbstractBlockBase extends BlockBase implements ContainerF
   use SubsitesHierarchyTrait;
 
   /**
+   * Entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Node being displayed.
    *
    * @var \Drupal\node\NodeInterface

--- a/src/Subsite.php
+++ b/src/Subsite.php
@@ -17,6 +17,13 @@ class Subsite implements ContainerInjectionInterface {
   use SubsitesHierarchyTrait;
 
   /**
+   * Entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Node being displayed.
    *
    * @var \Drupal\node\NodeInterface


### PR DESCRIPTION
Suppressing PHP 8.2's dynamic property deprecation warnings.

@see https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties