### PR TITLE
Add services parent to subsite overviews #148

### DIFF
--- a/config/install/core.entity_form_display.node.localgov_subsites_page.default.yml
+++ b/config/install/core.entity_form_display.node.localgov_subsites_page.default.yml
@@ -109,7 +109,7 @@ content:
     type: layout_paragraphs
     region: content
   localgov_subsites_parent:
-    weight: -3
+    weight: -6
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/install/field.field.node.localgov_subsites_page.localgov_subsites_parent.yml
+++ b/config/install/field.field.node.localgov_subsites_page.localgov_subsites_parent.yml
@@ -11,7 +11,7 @@ id: node.localgov_subsites_page.localgov_subsites_parent
 field_name: localgov_subsites_parent
 entity_type: node
 bundle: localgov_subsites_page
-label: Parent
+label: 'Subsite parent page'
 description: ''
 required: true
 translatable: false
@@ -25,6 +25,7 @@ settings:
       localgov_subsites_page: localgov_subsites_page
     sort:
       field: _none
+      direction: ASC
     auto_create: false
     auto_create_bundle: localgov_subsites_overview
   weight_min: -50

--- a/config/optional/field.field.node.localgov_subsites_overview.localgov_services_parent.yml
+++ b/config/optional/field.field.node.localgov_subsites_overview.localgov_services_parent.yml
@@ -10,7 +10,7 @@ id: node.localgov_subsites_overview.localgov_services_parent
 field_name: localgov_services_parent
 entity_type: node
 bundle: localgov_subsites_overview
-label: 'Parent page'
+label: 'Service parent page'
 description: ''
 required: false
 translatable: true

--- a/config/optional/field.field.node.localgov_subsites_overview.localgov_services_parent.yml
+++ b/config/optional/field.field.node.localgov_subsites_overview.localgov_services_parent.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_services_parent
+    - node.type.localgov_subsites_overview
+    - node.type.localgov_services_landing
+    - node.type.localgov_services_sublanding
+id: node.localgov_subsites_overview.localgov_services_parent
+field_name: localgov_services_parent
+entity_type: node
+bundle: localgov_subsites_overview
+label: 'Parent page'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: localgov_services
+  handler_settings:
+    target_bundles:
+      localgov_services_landing: localgov_services_landing
+      localgov_services_sublanding: localgov_services_sublanding
+field_type: entity_reference

--- a/localgov_subsites.install
+++ b/localgov_subsites.install
@@ -8,7 +8,10 @@
 /**
  * Implements hook_install().
  */
-function localgov_subsites_install() {
+function localgov_subsites_install($is_syncing) {
+  if ($is_syncing) {
+    return;
+  }
 
   if (\Drupal::moduleHandler()->moduleExists('localgov_services_navigation')) {
     localgov_subsites_optional_fields_settings();

--- a/localgov_subsites.install
+++ b/localgov_subsites.install
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Implements hook_install()
+ */
+function localgov_subsites_install() {
+
+  if (\Drupal::moduleHandler()->moduleExists('localgov_services_navigation')) {
+    localgov_subsites_optional_fields_settings();
+  }
+}
+
+/**
  * Clear caches after moving subsites paragraphs to localgov_paragraphs.
  */
 function localgov_subsites_update_9001() {

--- a/localgov_subsites.install
+++ b/localgov_subsites.install
@@ -6,7 +6,7 @@
  */
 
 /**
- * Implements hook_install()
+ * Implements hook_install().
  */
 function localgov_subsites_install() {
 

--- a/localgov_subsites.module
+++ b/localgov_subsites.module
@@ -5,6 +5,7 @@
  * LocalGov Subsites module file.
  */
 
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\localgov_roles\RolesHelper;
 use Drupal\localgov_subsites\Subsite;
 use Drupal\node\NodeInterface;
@@ -139,6 +140,45 @@ function localgov_subsites_preprocess_page(&$variables) {
 
     if ($subsite instanceof NodeInterface && isset($subsite->localgov_subsites_theme->value) && $theme = $subsite->localgov_subsites_theme->value) {
       $variables['attributes']['class'][] = str_replace('_', '--', $theme);
+    }
+  }
+}
+
+/**
+ * Set form settings for optional services fields on installation.
+ */
+function localgov_subsites_optional_fields_settings() {
+
+  $form_displays = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->loadByProperties([
+      'targetEntityType' => 'node',
+      'bundle' => 'localgov_subsites_overview',
+    ]);
+  if ($form_displays) {
+    foreach ($form_displays as $form_display) {
+      assert($form_display instanceof EntityFormDisplayInterface);
+      if (!$form_display->getComponent('localgov_services_parent')) {
+        $form_display->setComponent('localgov_services_parent', [
+          'type' => 'entity_reference_autocomplete',
+          'region' => 'content',
+          'settings' => [
+            'match_operator' => 'CONTAINS',
+            'size' => '60',
+            'placeholder' => '',
+            'match_limit' => 10,
+          ],
+          'weight' => -1,
+        ])->save();
+        if (
+          ($field_groups = $form_display->getThirdPartySettings('field_group')) &&
+          ($group = $field_groups['group_description'] ?? FALSE)
+        ) {
+          $group['children'][] = 'localgov_services_parent';
+          $form_display->setThirdPartySetting('field_group', 'group_description', $group)
+            ->save();
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a parent page field to subsite overview pages. When this is used the subsite will appear in the services heirachy.

![image](https://github.com/localgovdrupal/localgov_subsites/assets/7189914/a8e09ca0-3686-4490-9c26-cec0f79751b0)

Fixes #148 