### PR TITLE
Fix WSOD on subsites when creating subsite page in front end theme

### DIFF
--- a/src/Plugin/Block/SubsitesHierarchyTrait.php
+++ b/src/Plugin/Block/SubsitesHierarchyTrait.php
@@ -114,7 +114,7 @@ trait SubsitesHierarchyTrait {
         'localgov_subsites_overview',
         'localgov_subsites_page',
       ], TRUE)
-      && is_numeric($entity->id())
+      && !is_null($entity->id())
     ) {
       if ($root_node = $this->getNestedSetStorage('localgov_subsites')->findRoot($this->getNestedSetNodeKeyFactory()->fromEntity($entity))) {
         return $root_node->getId();

--- a/src/Plugin/Block/SubsitesHierarchyTrait.php
+++ b/src/Plugin/Block/SubsitesHierarchyTrait.php
@@ -114,6 +114,7 @@ trait SubsitesHierarchyTrait {
         'localgov_subsites_overview',
         'localgov_subsites_page',
       ], TRUE)
+      && is_numeric($entity->id())
     ) {
       if ($root_node = $this->getNestedSetStorage('localgov_subsites')->findRoot($this->getNestedSetNodeKeyFactory()->fromEntity($entity))) {
         return $root_node->getId();

--- a/tests/src/Functional/SubsiteBlocksTest.php
+++ b/tests/src/Functional/SubsiteBlocksTest.php
@@ -11,6 +11,7 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\TestFileCreationTrait;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Tests user blocks.
@@ -66,7 +67,9 @@ class SubsiteBlocksTest extends BrowserTestBase {
       [
         'administer blocks',
         'create localgov_subsites_overview content',
+        'create localgov_subsites_page content',
         'edit any localgov_subsites_overview content',
+        'edit any localgov_subsites_page content',
       ]
     );
   }
@@ -244,6 +247,30 @@ class SubsiteBlocksTest extends BrowserTestBase {
     $this->assertSession()->responseContains($subsite_page1_title);
     $this->assertSession()->responseContains($subsite_page2_title);
     $this->assertSession()->pageTextNotContains($subsite_overview_title);
+  }
+
+  /**
+   * Test subsite blocks on node creation forms.
+   *
+   * This is for cases when using Mercury editor or page builders that use the
+   * front end theme.
+   *
+   * @see https://github.com/localgovdrupal/localgov_subsites/issues/154
+   */
+  public function testSubsiteBlocksOnCreateNodePage() {
+
+    // Login and place blocks.
+    $this->drupalLogin($this->adminUser);
+    $this->drupalPlaceBlock('localgov_subsite_banner', ['region' => 'content']);
+    $this->drupalPlaceBlock('localgov_subsite_navigation');
+
+    // Check create new subsite overview page does not crash.
+    $this->drupalGet('/node/add/localgov_subsites_overview');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
+
+    // Check create new subsite page does not crash.
+    $this->drupalGet('/node/add/localgov_subsites_page');
+    $this->assertSession()->statusCodeEquals(Response::HTTP_OK);
   }
 
 }


### PR DESCRIPTION
Fix #154

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Checks the entity ID is numeric (is not null) when trying to find subsite.
Adds a test to verify status code is 200 (500 without this fix).


## How to test

1. Set appearance to use the front end theme as the admin theme, or use an editor like [mercury editor](https://dgo.to/mercury_editor).
2. Create a new Subsite page at /node/add/localgov_subsite_page
3. Should be able to add a page without errors.

## How can we measure success?

Creating a subsite page no longer crashes.

## Have we considered potential risks?

Need to check side effects on the blocks not finding their subsite.
I noticed that using `is_int` does fail as `$entity->id()` brings back a string, might fail strict types.

## Images

N/A - Using front end theme is optional for sites that want to do so.

## Accessibility

N/A