### PR TITLE
fix: coding standards introduced by latest drupal coder rules

### DIFF
--- a/tests/src/Functional/LocalgovIntegrationTest.php
+++ b/tests/src/Functional/LocalgovIntegrationTest.php
@@ -2,11 +2,11 @@
 
 namespace Drupal\Tests\localgov_subsites\Functional;
 
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\Traits\Core\CronRunTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
-use Drupal\Tests\Traits\Core\CronRunTrait;
+use Drupal\node\NodeInterface;
 
 /**
  * Tests pages working together with LocalGov: pathauto, services, search.

--- a/tests/src/Functional/SubsiteBlocksTest.php
+++ b/tests/src/Functional/SubsiteBlocksTest.php
@@ -3,14 +3,14 @@
 namespace Drupal\Tests\localgov_subsites\Functional;
 
 use Drupal\Core\Database\Database;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\TestFileCreationTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 use Drupal\media\Entity\Media;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
-use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\node\Traits\NodeCreationTrait;
-use Drupal\Tests\TestFileCreationTrait;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/tests/src/Functional/SubsitePagesTest.php
+++ b/tests/src/Functional/SubsitePagesTest.php
@@ -3,10 +3,10 @@
 namespace Drupal\Tests\localgov_subsites\Functional;
 
 use Drupal\Core\Database\Database;
-use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+use Drupal\node\NodeInterface;
 
 /**
  * Tests LocalGov Subsite pages work together.

--- a/tests/src/Kernel/SubsitesHierarchyTraitTest.php
+++ b/tests/src/Kernel/SubsitesHierarchyTraitTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\localgov_subsites\Kernel;
 
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\localgov_subsites\Plugin\Block\SubsitesHierarchyTrait;
-use Drupal\node\NodeInterface;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\localgov_subsites\Plugin\Block\SubsitesHierarchyTrait;
+use Drupal\node\NodeInterface;
 
 /**
  * Test SubsitesHierarchyTrait methods.


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This fixes the following coding standards that are now enabled by drupal coder

- https://www.drupal.org/project/coder/issues/3470716
- https://www.drupal.org/node/3471146