### PR TITLE
2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/entity_hierarchy": "^3.3",
-        "drupal/tablefield": "^2.2",
+        "drupal/tablefield": "^2.4 || ^3.0@beta",
         "drupal/viewsreference": "^2.0",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_paragraphs": "^2.3"

--- a/localgov_subsites.info.yml
+++ b/localgov_subsites.info.yml
@@ -1,6 +1,6 @@
 name: LocalGov Subsites
 description: Provides subsite sections using page builder paragraph types for LocalGov Drupal.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 type: module
 package: LocalGov Drupal
 

--- a/src/EventSubscriber/PageHeaderSubscriber.php
+++ b/src/EventSubscriber/PageHeaderSubscriber.php
@@ -16,7 +16,7 @@ class PageHeaderSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       PageHeaderDisplayEvent::EVENT_NAME => ['setPageHeader', 0],
     ];


### PR DESCRIPTION
Add support for Drupal 11.

Note: Tablefield can now upgrade to 3.x 
Check before upgrade if you need to remain on 2.4 or can upgrade to 3.0