### PR TITLE
Add config for simple sitemap

### DIFF
--- a/localgov_subsites.install
+++ b/localgov_subsites.install
@@ -24,7 +24,8 @@ function localgov_subsites_install($is_syncing) {
     $generator = \Drupal::service('simple_sitemap.entity_manager');
     $generator->setBundleSettings('node', 'localgov_subsites_overview', [
       'index' => TRUE,
-      'priority' => '1.0', // Cast as string to ensure the value is properly set
+      // Cast as string to ensure the value is properly set.
+      'priority' => '1.0',
     ]);
     $generator->setBundleSettings('node', 'localgov_subsites_page', [
       'index' => TRUE,

--- a/localgov_subsites.install
+++ b/localgov_subsites.install
@@ -16,6 +16,21 @@ function localgov_subsites_install($is_syncing) {
   if (\Drupal::moduleHandler()->moduleExists('localgov_services_navigation')) {
     localgov_subsites_optional_fields_settings();
   }
+
+  // Install default config for simple_sitemap, as this does not appear to work
+  // in the config/optional folder.
+  // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
+  if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
+    $generator = \Drupal::service('simple_sitemap.entity_manager');
+    $generator->setBundleSettings('node', 'localgov_subsites_overview', [
+      'index' => TRUE,
+      'priority' => 1.0,
+    ]);
+    $generator->setBundleSettings('node', 'localgov_subsites_page', [
+      'index' => TRUE,
+      'priority' => 0.5,
+    ]);
+  }
 }
 
 /**

--- a/localgov_subsites.install
+++ b/localgov_subsites.install
@@ -24,11 +24,11 @@ function localgov_subsites_install($is_syncing) {
     $generator = \Drupal::service('simple_sitemap.entity_manager');
     $generator->setBundleSettings('node', 'localgov_subsites_overview', [
       'index' => TRUE,
-      'priority' => 1.0,
+      'priority' => '1.0', // Cast as string to ensure the value is properly set
     ]);
     $generator->setBundleSettings('node', 'localgov_subsites_page', [
       'index' => TRUE,
-      'priority' => 0.5,
+      'priority' => '0.5',
     ]);
   }
 }


### PR DESCRIPTION
Closes #123

## What does this change?
Adds default config for simple sitemap - same approach as LocalGov News.

## How to test

Install the subsites module, make sure subsites overview and page content types now both have default sitemap settings.
